### PR TITLE
Resolves #5 by making _modify_ only accept POST calls

### DIFF
--- a/editlink.html
+++ b/editlink.html
@@ -16,7 +16,7 @@
   {% endif %}
 
 <div class="inner">
- <form action="/_modify_">
+ <form action="/_modify_" method="POST">
   {% if returnto %}
     <input type="hidden" name="returnto" value="{{ returnto|escapekeyword }}"/>
   {% endif %}

--- a/go.py
+++ b/go.py
@@ -940,6 +940,7 @@ class Root:
         return self.redirect("/." + returnto)
 
     @cherrypy.expose
+    @cherrypy.tools.allow(methods=['POST'])
     def _modify_(self, **kwargs):
         username = getSSOUsername()
 


### PR DESCRIPTION
Validated via manual creation/editing of URLs.  Here is the new log output as evidence that it is using the POST method like it should have been:

```
::1 - - [11/Jun/2016:00:45:27] "GET /_edit_/1?returnto= HTTP/1.1" 200 3977 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:31] "POST /_modify_ HTTP/1.1" 307 - "http://localhost:8080/_edit_/1?returnto=" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:31] "POST / HTTP/1.1" 200 4162 "http://localhost:8080/_edit_/1?returnto=" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:31] "GET /images/edititem.gif HTTP/1.1" 200 2397 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:34] "GET /?keyword=test HTTP/1.1" 307 - "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:34] "GET /test HTTP/1.1" 200 2388 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:35] "GET /_add_/test HTTP/1.1" 200 3717 "http://localhost:8080/test" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:42] "POST /_modify_ HTTP/1.1" 307 - "http://localhost:8080/_add_/test" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:42] "POST /.test HTTP/1.1" 200 3683 "http://localhost:8080/_add_/test" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
::1 - - [11/Jun/2016:00:45:42] "GET /images/edititem.gif HTTP/1.1" 200 2397 "http://localhost:8080/.test" "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
```