### PR TITLE
Merge the private and public versions changes

### DIFF
--- a/go.cfg
+++ b/go.cfg
@@ -11,5 +11,17 @@ cfg_urlFavicon: http://www.example.com/favicon.ico
 # FQDN where go.py will run
 cfg_hostname: localhost
 
+# Port to use for the web service
+cfg_port: 8080
+
 # (optional) Auth URL for redirecting users when editing links
 cfg_urlSSO: None
+
+# (optional) Use SSL?  If enabled this will make cfg_sslCertificate and cfg_sslPrivateKey required
+cfg_sslEnabled: false
+
+# The path to the SSL certificate
+cfg_sslCertificate: go.crt
+
+# The path to the SSL private key
+cfg_sslPrivateKey: go.key

--- a/go.py
+++ b/go.py
@@ -7,7 +7,7 @@ common phone numbers, and just about everyone needs a way around bookmarks.
 """
 
 __author__ = "Saul Pwanson <saul@pwanson.com>"
-__credits__ = "Bill Booth, Bryce Bockman, treebird"
+__credits__ = "Bill Booth, Bryce Bockman, treebird, Sean Smith"
 
 import base64
 import cgi

--- a/go.py
+++ b/go.py
@@ -195,7 +195,7 @@ def getSSOUsername(redirect=True):
     :param redirect:
     :return: the SSO username
     """
-    if cfg_urlSSO is None or 'None':
+    if cfg_urlSSO is None or cfg_urlSSO == 'None':
         return 'testuser'
 
     if cherrypy.request.base != cfg_urlEditBase:

--- a/go.py
+++ b/go.py
@@ -43,7 +43,7 @@ cfg_urlEditBase = "https://" + cfg_hostname
 cfg_sslEnabled = False # default to False
 try:
     cfg_sslEnabled = config.getboolean('goconfig', 'cfg_sslEnabled')
-except ValueError:
+except:
     # just preventing from crashing if the cfg option doesn't exist since technically it's optional
     pass
 cfg_sslCertificate = config.get('goconfig', 'cfg_sslCertificate')

--- a/go.py
+++ b/go.py
@@ -525,7 +525,7 @@ class RegexList(ListOfLinks):
         if m:
             deflink = self.getDefaultLink()
             for L in deflink and [deflink] or self.links:
-                url = L.url(keyword=kw, args=(m.group(0)) + m.groups())
+                url = L.url(keyword=kw, args=(m.group(0), ) + m.groups())
                 ret.append((L, Link(0, url, L.title)))
 
         return ret
@@ -539,7 +539,7 @@ class RegexList(ListOfLinks):
         if not m:
             return None
 
-        return ListOfLinks.url(self, keyword=kw, args=(m.group(0)) + m.groups())
+        return ListOfLinks.url(self, keyword=kw, args=(m.group(0), ) + m.groups())
 
     def _export(self):
         return ("regex %s " % self.regex) + ListOfLinks._export(self)

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 <div class="span6 column">
 <h4 class="center"><a href="/special">Special Cases</a></h4>
 <table class="table table-striped">
-{% for link in folderLinks[:15]: %}
-    {{ renderlink(0, link, username) }}
+{% for idx, link in enumerate(folderLinks[:15]): %}
+    {{ renderlink(idx + 1, link, username) }}
 {% endfor %}
 </table>
 </div>


### PR DESCRIPTION
In order to create one codebase I've merged in (and made some changes) to allow for one unified code base for the github version of the go redirector as well as the internal one used at f5 networks.  I am currently running tests internally to verify everything works but it is looking good to allow one version and make maintaining this tool easier.