### PR TITLE
Fix some tag issues and make the email/docs page configurable

### DIFF
--- a/go.cfg
+++ b/go.cfg
@@ -6,7 +6,7 @@
 cfg_fnDatabase: godb.pickle
 
 # F5's favicon for use in client browsers
-cfg_urlFavicon: http://www.example.com/favicon.ico
+cfg_urlFavicon: http://www.f5.com/favicon.ico
 
 # FQDN where go.py will run
 cfg_hostname: localhost
@@ -25,3 +25,12 @@ cfg_sslCertificate: go.crt
 
 # The path to the SSL private key
 cfg_sslPrivateKey: go.key
+
+# The email address of a person to contact if there is a question/problem/etc. which will show up at the bottom of pages if set.
+cfg_contactEmail: None
+
+# The name of a person to contact if there is a question/problem/etc. which will show up at the bottom of pages if set.
+cfg_contactName: None
+
+# A URL to internal documentation written for your Go redirector instance which will show up at the bottom of pages if set
+cfg_customDocs: None

--- a/go.py
+++ b/go.py
@@ -253,6 +253,10 @@ class Clickable:
             raise AttributeError(attrname)
 
     def clicked(self, n=1):
+        """
+        :param n: The number of clicks to record
+        :return:
+        """
         todayord = today()
         if todayord not in self.clickData:
             # partition clickdata around 30 days ago

--- a/go.py
+++ b/go.py
@@ -48,7 +48,9 @@ except:
     pass
 cfg_sslCertificate = config.get('goconfig', 'cfg_sslCertificate')
 cfg_sslPrivateKey = config.get('goconfig', 'cfg_sslPrivateKey')
-
+cfg_contactEmail = config.get('goconfig', 'cfg_contactEmail')
+cfg_contactName = config.get('goconfig', 'cfg_contactName')
+cfg_customDocs = config.get('goconfig', 'cfg_customDocs')
 
 class MyGlobals(object):
     def __init__(self):

--- a/go_test.py
+++ b/go_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import datetime
 import unittest
 import time
 
@@ -175,6 +176,51 @@ class GeneralTestCases(unittest.TestCase):
         # TODO: Will have to be changed if/when SSO is made generic
         self.assertEqual("testuser", go.getSSOUsername())
 
+
+class LinkTestCases(unittest.TestCase):
+    def test_create_link(self):
+        link = go.Link(url='www.example.com', title='example site')
+        self.assertEqual(0, link.linkid)
+        self.assertEqual('example site', link.title)
+
+    def test_edit_link(self):
+        """
+        Validate the last edit user starts off blank and then adds a users when edited
+        :return:
+        """
+        link = go.Link(url='example.com', title='example site')
+        (last_edit_time, last_edit_name) = link.lastEdit()
+        self.assertEqual(0, last_edit_time)
+        self.assertEqual('', last_edit_name)
+
+        link.editedBy('testuser')
+        (_, last_edit_name) = link.lastEdit()
+        self.assertEqual('testuser', last_edit_name)
+
+    def test_opacity_never_clicked(self):
+        """
+        By default the opacity is 0.2
+        :return:
+        """
+        link = go.Link(url='example.com', title='example site')
+        today = datetime.date.today()
+        date = datetime.date.toordinal(today)
+        self.assertEqual('0.20', link.opacity(date))
+
+    def test_opacity_clicked_today(self):
+        """
+        By default the opacity is 0.2, by "clicking" today it's set to 1.0
+        :return:
+        """
+        link = go.Link(url='example.com', title='example site')
+        today = datetime.date.today()
+        date = datetime.date.toordinal(today)
+        link.clicked()
+        self.assertEqual('1.00', link.opacity(date))
+
+    def test_usage_not_exists(self):
+        link = go.Link(url='example.com', title='example site')
+        self.assertEqual('', link.usage())
 
 if __name__ == '__main__':
     unittest.main()

--- a/html/base.html
+++ b/html/base.html
@@ -2,7 +2,7 @@
 <html lang="en"><head>
 <title>{% block title %}go/{% block titlekeyword %}{% endblock titlekeyword %}{% endblock title %}</title>
 <link rel="stylesheet" href="/css/bootstrap.min.css" media="screen"/>
-<link rel="shortcut icon" href="http://www.f5.com/favicon.ico" />
+<link rel="shortcut icon" href="{{cfg_urlFavicon}}" />
 
 <style type="text/css">
     a { text-decoration: none; }
@@ -101,6 +101,17 @@
 {% endblock body %}
 
 <hr style="clear:both;"/>
+    {# If cfg_contactEmail exists and is not "None" then display it #}
+    {% if cfg_contactEmail is defined and cfg_contactEmail|string() != "None" %}
+<p>Problems, questions, suggestions? <a href="mailto:{{ cfg_contactEmail }}">email {{ cfg_contactName }}</a>.</p>
+    {% endif %}
+
+    {# If cfg_customDocs exists and is not "None" then display it #}
+    {% if cfg_customDocs is defined and cfg_customDocs != "None" %}
+<div>
+<a href="{{cfg_customDocs}}">GO redirector information page</a>
+</div>
+    {% endif %}
 </div>
 
 <script type="text/javascript">

--- a/html/base.html
+++ b/html/base.html
@@ -102,12 +102,12 @@
 
 <hr style="clear:both;"/>
     {# If cfg_contactEmail exists and is not "None" then display it #}
-    {% if cfg_contactEmail is defined and cfg_contactEmail|string() != "None" %}
+    {% if cfg_contactEmail is defined and cfg_contactEmail != None and cfg_contactEmail != "None" %}
 <p>Problems, questions, suggestions? <a href="mailto:{{ cfg_contactEmail }}">email {{ cfg_contactName }}</a>.</p>
     {% endif %}
 
     {# If cfg_customDocs exists and is not "None" then display it #}
-    {% if cfg_customDocs is defined and cfg_customDocs != "None" %}
+    {% if cfg_customDocs is defined and cfg_customDocs != None and cfg_customDocs != "None" %}
 <div>
 <a href="{{cfg_customDocs}}">GO redirector information page</a>
 </div>

--- a/html/index.html
+++ b/html/index.html
@@ -20,7 +20,7 @@
 </div>
 
 <div class="span6 column">
-<h4 class="center"><a href="/toplinks?n=100">Recent Top Links</a></h3>
+<h4 class="center"><a href="/toplinks?n=100">Recent Top Links</a></h4>
 <table class="table table-striped">
 <!-- Check to see if topLinks is empty (new database) -->
 {% if topLinks %}
@@ -36,7 +36,7 @@
 
 </div>
 
-<h4>Lists used in last 30 days</h3>
+<h4>Lists used in last 30 days</h4>
 <div>
   {% for LL in g_db.getAllLists() %}
   <div class="cloudli">


### PR DESCRIPTION
The internal version has a contact email as well as an internal docs page at the bottom, make that configurable to allow for 1 unified version of the go redirector.