### PR TITLE
Fixes #9 create popup confirmation dialog that verifies you want to delete

### DIFF
--- a/go.py
+++ b/go.py
@@ -1097,7 +1097,8 @@ def main():
 
     file_path = os.getcwd().replace("\\", "/")
     conf = {'/images': {"tools.staticdir.on": True, "tools.staticdir.dir": file_path + "/images"},
-            '/css': {"tools.staticdir.on": True, "tools.staticdir.dir": file_path + "/css"}}
+            '/css': {"tools.staticdir.on": True, "tools.staticdir.dir": file_path + "/css"},
+            '/js': {"tools.staticdir.on": True, "tools.staticdir.dir": file_path + "/js"}}
     print "Cherrypy conf: %s" % conf
     cherrypy.quickstart(Root(), "/", config=conf)
 

--- a/html/editlink.html
+++ b/html/editlink.html
@@ -12,7 +12,7 @@
 <div class="column span6">
 
   {% if L.linkid != 0 %}
-  <a class="pull-right" style="margin-right: .25em;" href="/_delete_/{{ L.linkid }}?returnto={{ returnto }}">DELETE</a>
+  <a class="pull-right" id="delete" style="margin-right: .25em;" href="/_delete_/{{ L.linkid }}?returnto={{ returnto }}">DELETE</a>
   {% endif %}
 
 <div class="inner">
@@ -94,4 +94,5 @@ and <a href="http://docs.python.org/library/re.html#regular-expression-syntax">P
 <br/>&mdash;&nbsp;{{ editTime|time_t }} by {{ editor }}
 {% endfor %}
 
+<script type="application/javascript" src="/js/go.js"></script>
 {% endblock body %}

--- a/js/go.js
+++ b/js/go.js
@@ -1,0 +1,28 @@
+/**
+ * Created by Sean Smith on 10/11/16.
+ */
+
+document.getElementById('delete').onclick = function () {
+    var lists = document.getElementsByName('lists');
+    var message = 'Doing this will delete the link from ';
+    if (lists.length == 1) {
+        message += 'the \'' + lists[0].value + '\' keyword';
+    }
+    else if (lists.length == 2) {
+        message += 'the following keywords: \'' + lists[0].value + '\' and \'' + lists[1].value + '\'';
+    } else {
+        message += 'the following keywords: ';
+        for (var i = 0; i < lists.length; i++) {
+            if (i + 1 != lists.length) {
+                message += '\'' + lists[i].value + '\', ';
+            }
+            else {
+                message += 'and \'' + lists[i].value + '\'';
+            }
+        }
+    }
+    if (lists.length > 1) {
+        message += '\n\nIf you just want to disassociate it from a keyword uncheck it and submit';
+    }
+    return confirm(message);
+};


### PR DESCRIPTION
Deleting is not necessarily intuitive in that it removes the link from all keywords associated with it and not just the one you clicked edit from.  This should cut down on the number of unknowing deletes.